### PR TITLE
V6.2.1 RAPI 5.1.0

### DIFF
--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,15 @@
 Change Log
 
+D6.2.0 20200327 SCL
+- fix 1 sec delay in showing current when charging starts
+- make space by taking stuff out of button menu that is still accessible via WiFi NOSETUP_MENU
+- add RAPI $FF B to enable/disable front button
+- fix bug in $AT.. was supposed to send GetCurrentCapacity(), not GetMaxCurrentCapacity()
+- change $GC .. new 4th returned parameter is max current capacity
+- bump RAPIVER to 5.1.0.
+  -> n.b. shouldn't really be using RAPIVER.. should just test for working
+	commands and # returned parameters
+
 D6.1.3 20191217 SCL
 - fix bug in displaying lock icon in SLEEP
 - update EVSE status after receiving $S4 command

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,9 @@
 Change Log
 
+D6.2.1 20200327 SCL
+- doPost() - don't compare against hardcoded 900 .. use ThreshAB
+- send $AT during sleep if EV connect/disconnect
+	
 D6.2.0 20200327 SCL
 - fix 1 sec delay in showing current when charging starts
 - make space by taking stuff out of button menu that is still accessible via WiFi NOSETUP_MENU

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,8 @@
 Change Log
 
+20200330 SCL
+- fixed SetAmmeterDirty(1) compile error
+	
 D6.2.1 20200327 SCL
 - doPost() - don't compare against hardcoded 900 .. use ThreshAB
 - send $AT during sleep if EV connect/disconnect

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1179,6 +1179,9 @@ void J1772EVSEController::Update(uint8_t forcetransition)
       }
 #endif // DELAYTIMER
 	g_OBD.Update(OBD_UPD_FORCE);
+#ifdef RAPI
+	RapiSendEvseState();
+#endif // RAPI	
       }
     }
 

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -697,7 +697,7 @@ uint8_t J1772EVSEController::doPost()
 #endif //#ifdef SERDBG
 
     m_Pilot.SetState(PILOT_STATE_N12);
-    if (reading > 900) {  // IF EV is not connected its Okay to open the relay the do the L1/L2 and ground Check
+    if (reading >= m_ThreshData.m_ThreshAB) {  // IF EV is not connected its Okay to open the relay the do the L1/L2 and ground Check
 
       // save state with both relays off - for stuck relay state
       RelayOff = ReadACPins();

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -80,6 +80,7 @@ typedef uint8_t (*EvseStateTransitionReqFunc)(uint8_t prevPilotState,uint8_t cur
 #define ECF_MONO_LCD           0x0100 // monochrome LCD backlight
 #define ECF_GFI_TEST_DISABLED  0x0200 // no GFI self test
 #define ECF_TEMP_CHK_DISABLED  0x0400 // no Temperature Monitoring
+#define ECF_BUTTON_DISABLED    0x8000 // front panel button disabled
 #define ECF_DEFAULT            0x0000
 
 // J1772EVSEController volatile m_wVFlags bits - not saved to EEPROM
@@ -188,6 +189,9 @@ class J1772EVSEController {
   }
   void clrFlags(uint16_t flags) { 
     m_wFlags &= ~flags; 
+  }
+  uint8_t flagIsSet(uint16_t flag) {
+    return (m_wFlags & flag) ? 1 : 0;
   }
   void setVFlags(uint16_t flags) { 
     m_wVFlags |= flags; 
@@ -519,6 +523,14 @@ int GetHearbeatTrigger();
   }
   void SetInMenu() { setVFlags(ECVF_UI_IN_MENU); }
   void ClrInMenu() { clrVFlags(ECVF_UI_IN_MENU); }
+#ifdef BTN_MENU
+  void ButtonEnable(uint8_t tf) {
+    if (!tf) setFlags(ECF_BUTTON_DISABLED); 
+    else clrFlags(ECF_BUTTON_DISABLED);
+    SaveEvseFlags();
+  }
+  uint8_t ButtonIsEnabled() { return flagIsSet(ECF_BUTTON_DISABLED) ? 0 : 1; }
+#endif // BTN_MENU
 };
 
 #ifdef FT_ENDURANCE

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -229,6 +229,10 @@ extern AutoCurrentCapacityController g_ACCController;
 // When within menus, short press cycles menu items, long press selects and exits current submenu
 #define BTN_MENU
 
+// take out basic setup stuff that the user really shouldn't be changing,
+// which can be set via RAPI/WiFi module.. reclaims a lot of code space
+#define NOSETUP_MENU
+
 // When not in menus, short press instantly stops the EVSE - another short press resumes.  Long press activates menus
 // also allows menus to be manipulated even when in State B/C
 #define BTN_ENABLE_TOGGLE

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -42,7 +42,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D6.1.3"
+#define VERSION "D6.2.0"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -42,7 +42,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D6.2.0"
+#define VERSION "D6.2.1"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -655,7 +655,9 @@ void OnboardDisplay::Update(int8_t updmode)
       LcdPrint_P(g_psCharging);
 #endif //Adafruit RGB LCD
       // n.b. blue LED is on
+#ifdef AMMETER
       SetAmmeterDirty(1); // force ammeter update code below
+#endif // AMMETER
       break;
     case EVSE_STATE_D: // vent required
       SetGreenLed(0);

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -649,6 +649,7 @@ void OnboardDisplay::Update(int8_t updmode)
       LcdPrint_P(g_psCharging);
 #endif //Adafruit RGB LCD
       // n.b. blue LED is on
+      SetAmmeterDirty(1); // force ammeter update code below
       break;
     case EVSE_STATE_D: // vent required
       SetGreenLed(0);

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2187,6 +2187,8 @@ int8_t BtnHandler::DoShortPress(int8_t infaultstate)
 
 void BtnHandler::ChkBtn()
 {
+  if (!g_EvseController.ButtonIsEnabled()) return;
+
   WDT_RESET();
 
   int8_t infaultstate = g_EvseController.InFaultState();

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -2419,13 +2419,6 @@ void EvseReset()
 {
   Wire.begin();
 
-#ifdef RTC
-  g_RTC.begin();
-#ifdef DELAYTIMER
-  g_DelayTimer.Init();
-#endif  // DELAYTIMER
-#endif // RTC
-
 #ifdef SERIALCLI
   g_CLI.Init();
 #endif // SERIALCLI
@@ -2437,6 +2430,14 @@ void EvseReset()
 #endif
 
   g_EvseController.Init();
+
+#ifdef RTC
+  g_RTC.begin();
+#ifdef DELAYTIMER
+  g_DelayTimer.Init(); // this *must* run after g_EvseController.Init() because it sets one of the vFlags
+#endif  // DELAYTIMER
+#endif // RTC
+
 
 #ifdef PP_AUTO_AMPACITY
   g_ACCController.AutoSetCurrentCapacity();

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -150,7 +150,7 @@ void EvseRapiProcessor::sendBootNotification()
 
 void EvseRapiProcessor::sendEvseState()
 {
-    sprintf(g_sTmp,"%cAT %02x %02x %d %04x",ESRAPI_SOC,g_EvseController.GetState(),g_EvseController.GetPilotState(),g_EvseController.GetMaxCurrentCapacity(),g_EvseController.GetVFlags());
+    sprintf(g_sTmp,"%cAT %02x %02x %d %04x",ESRAPI_SOC,g_EvseController.GetState(),g_EvseController.GetPilotState(),g_EvseController.GetCurrentCapacity(),g_EvseController.GetVFlags());
   appendChk(g_sTmp);
   writeStart();
   write(g_sTmp);

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -570,7 +570,8 @@ int EvseRapiProcessor::processCmd()
 	u2.i = MAX_CURRENT_CAPACITY_L1;
       }
       u3.i = g_EvseController.GetCurrentCapacity();
-      sprintf(buffer,"%d %d %d",u1.i,u2.i,u3.i);
+      u4.i = g_EvseController.GetMaxCurrentCapacity();
+      sprintf(buffer,"%d %d %d %d",u1.i,u2.i,u3.i,u4.i);
       bufCnt = 1; // flag response text output
       rc = 0;
       break;

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -277,6 +277,11 @@ int EvseRapiProcessor::processCmd()
 	if (u1.u8 <= 1) {
 	  rc = 0;
 	  switch(*tokens[1]) {
+#ifdef BTN_MENU
+	  case 'B': // front button enable
+	    g_EvseController.ButtonEnable(u1.u8);
+	    break;
+#endif // BTN_MENU
 	  case 'D': // diode check
 	    g_EvseController.EnableDiodeCheck(u1.u8);
 	    break;

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -220,11 +220,13 @@ GA - get ammeter settings
  $GA^22
 
 GC - get current capacity info
- response: $OK minamps maxamps pilotamps
+ response: $OK minamps hmaxamps pilotamps cmaxamps
  all values decimal
  minamps - min allowed current capacity
- maxamps - max allowed current capacity
+ hmaxamps - max hardware allowed current capacity MAX_CURRENT_CAPACITY_Ln
  pilotamps - current capacity advertised by pilot
+ cmaxamps - max configured allowed current capacity (saved to EEPROM)
+ n.b. maxamps,emaxamps values are dependent on the active service level (L1/L2)
  $GC^20
 
 GD - get Delay timer
@@ -315,7 +317,7 @@ Z0 closems holdpwm
 
 #ifdef RAPI
 
-#define RAPIVER "5.0.0"
+#define RAPIVER "5.1.0"
 
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_CLIENT 1

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -125,6 +125,7 @@ FF - enable/disable feature
  $FF feature_id 0|1
  0|1 0=disable 1=enable
  feature_id:
+  B = disable/enable front panel button
   D = Diode check
   E = command Echo
    use this for interactive terminal sessions with RAPI.


### PR DESCRIPTION
- fixed SetAmmeterDirty(1) compile error

D6.2.1 20200327 SCL
- doPost() - don't compare against hardcoded 900 .. use ThreshAB
- send $AT during sleep if EV connect/disconnect

D6.2.0 20200327 SCL
- fix 1 sec delay in showing current when charging starts
- make space by taking stuff out of button menu that is still accessible via WiFi `NOSETUP_MENU` https://github.com/openenergymonitor/open_evse/commit/9c487b5acd16dc5aef9e65ce1f4376959e56c95e
- add RAPI $FF B to enable/disable front button
- fix bug in $AT.. was supposed to send GetCurrentCapacity(), not GetMaxCurrentCapacity()
- send $AT during sleep for EV connect/disconnect https://github.com/openenergymonitor/open_evse/commit/faf39ff78fb322cf4505e023831f7798398c2887
- change $GC .. new 4th returned parameter is max set current capacity https://github.com/openenergymonitor/open_evse/commit/68f362cd073827eae03f8dace6947072f428e919
- bump RAPIVER to 5.1.0.
  -> n.b. shouldn't really be using RAPIVER.. should just test for working
	commands and # returned parameters