### PR TITLE
V7.0.1 RAPI 5.1.3

### DIFF
--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,9 @@
 Change Log
 
+D6.3.0 2020420 SCL
+- merge $SC M code from oev6 branch
+- merge PR#120
+	
 20200330 SCL
 - fixed SetAmmeterDirty(1) compile error
 	

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,8 @@
 Change Log
 
+20200507 SCL V7.0.1
+- added $SV
+	
 20200507 SCL V7.0.0
 changes 20200411 merged from oev6 branch
 - added OpenEVSE V6 support

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,14 @@
 Change Log
 
+20200507 SCL V7.0.0
+changes 20200411 merged from oev6 branch
+- added OpenEVSE V6 support
+  - detection by looking for PD7 LOW
+  - RELAY_PWM - close relay w/ DC and the switch to PWM for hold
+  - if not V6 hardware detected same behavior as before on charging pin
+- added $SC M to set max hardware current capacity. Can be written only once
+N.B. AUTODETECT OF PRE-V6 HARDWARE IS CURRENTLY BROKEN PENDING NEW SPIN OF V6
+
 D6.3.0 2020420 SCL
 - merge $SC M code from oev6 branch
 - merge PR#120

--- a/firmware/open_evse/EnergyMeter.cpp
+++ b/firmware/open_evse/EnergyMeter.cpp
@@ -59,15 +59,11 @@ void EnergyMeter::calcUsage()
   unsigned long dms = curms - m_lastUpdateMs;
   if (dms > KWH_CALC_INTERVAL_MS) {
       uint32_t ma = g_EvseController.GetChargingCurrent();
-#ifdef VOLTMETER
-      m_wattSeconds += ((g_EvseController.GetVoltage()/1000UL) * (ma/1000UL) * dms) / 1000UL;
-#else // !VOLTMETER
 #ifdef THREEPHASE //Multiple L1 current by the square root of 3 to get 3-phase energy
-      m_wattSeconds += (((g_EvseController.GetCurSvcLevel() == 2) ? VOLTS_FOR_L2:VOLTS_FOR_L1) * (ma/1000UL) * dms * 3) / 1000UL;
+      m_wattSeconds += ((g_EvseController.GetVoltage()/1000UL) * (ma/1000UL) * dms * 3) / 1000UL;
 #else // !THREEPHASE
-     m_wattSeconds += (((g_EvseController.GetCurSvcLevel() == 2) ? VOLTS_FOR_L2:VOLTS_FOR_L1) * (ma/1000UL) * dms) / 1000UL;
+      m_wattSeconds += ((g_EvseController.GetVoltage()/1000UL) * (ma/1000UL) * dms) / 1000UL;
 #endif // THREEPHASE
-#endif // VOLTMETER
 
       m_lastUpdateMs = curms;
   }

--- a/firmware/open_evse/EnergyMeter.h
+++ b/firmware/open_evse/EnergyMeter.h
@@ -3,9 +3,9 @@
 
 #ifdef KWH_RECORDING
 
-#define VOLTS_FOR_L1 120       // conventional for North America
+#define MV_FOR_L1 120000L       // conventional for North America
 //  #define VOLTS_FOR_L2 230   // conventional for most of the world
-#define VOLTS_FOR_L2 240       // conventional for North America
+#define MV_FOR_L2 240000L       // conventional for North America
 
 
 // m_bFlags

--- a/firmware/open_evse/Gfi.cpp
+++ b/firmware/open_evse/Gfi.cpp
@@ -28,14 +28,22 @@ void gfi_isr()
 }
 
 
-void Gfi::Init()
+void Gfi::Init(uint8_t v6)
 {
   pin.init(GFI_REG,GFI_IDX,DigitalPin::INP);
   // GFI triggers on rising edge
   attachInterrupt(GFI_INTERRUPT,gfi_isr,RISING);
 
 #ifdef GFI_SELFTEST
-  pinTest.init(GFITEST_REG,GFITEST_IDX,DigitalPin::OUT);
+  volatile uint8_t *reg = GFITEST_REG;
+  volatile uint8_t idx  = GFITEST_IDX;
+#ifdef OEV6
+  if (v6) {
+    reg = V6_GFITEST_REG;
+    idx  = V6_GFITEST_IDX;
+  }
+#endif // OEV6
+  pinTest.init(reg,idx,DigitalPin::OUT);
 #endif
 
   Reset();

--- a/firmware/open_evse/Gfi.h
+++ b/firmware/open_evse/Gfi.h
@@ -36,7 +36,7 @@ public:
 
   Gfi() {}
 
-  void Init();
+  void Init(uint8_t v6=0);
   void Reset();
   void SetFault() { m_GfiFault = 1; }
   uint8_t Fault() { return m_GfiFault; }

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -949,8 +949,8 @@ void J1772EVSEController::Init()
   m_relayCloseMs = eeprom_read_byte((uint8_t*)EOFS_RELAY_CLOSE_MS);
   m_relayHoldPwm = eeprom_read_byte((uint8_t*)EOFS_RELAY_HOLD_PWM);
   if (!m_relayCloseMs || (m_relayCloseMs == 255)) {
-    m_relayCloseMs = 25;
-    m_relayHoldPwm = 70;
+    m_relayCloseMs = DEFAULT_RELAY_CLOSE_MS;
+    m_relayHoldPwm = DEFAULT_RELAY_HOLD_PWM;
   }
   Serial.print("\nrelayCloseMs: ");Serial.println(m_relayCloseMs);
   Serial.print("relayHoldPwm: ");Serial.println(m_relayHoldPwm);

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -581,10 +581,12 @@ void J1772EVSEController::SetSvcLevel(uint8_t svclvl,uint8_t updatelcd)
 #endif //#ifdef SERDBG
   if (svclvl == 2) {
     m_wFlags |= ECF_L2; // set to Level 2
+    m_Voltage = MV_FOR_L2;
   }
   else {
     svclvl = 1; // force invalid value to L1
     m_wFlags &= ~ECF_L2; // set to Level 1
+    m_Voltage = MV_FOR_L1;
   }
 
   SaveEvseFlags();

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -167,6 +167,7 @@ class J1772EVSEController {
   uint8_t m_PilotState;
   unsigned long m_TmpEvseStateStart;
   unsigned long m_TmpPilotStateStart;
+  uint8_t m_MaxHwCurrentCapacity; // max L2 amps that can be set
   uint8_t m_CurrentCapacity; // max amps we can output
   unsigned long m_ChargeOnTimeMS; // millis() when relay last closed
   unsigned long m_ChargeOffTimeMS; // millis() when relay last opened
@@ -307,6 +308,8 @@ public:
   int8_t InHardFault() { return vFlagIsSet(ECVF_HARD_FAULT); }
   unsigned long GetResetMs();
 
+  uint8_t SetMaxHwCurrentCapacity(uint8_t amps);
+  uint8_t GetMaxHwCurrentCapacity() { return m_MaxHwCurrentCapacity; }
   uint8_t GetCurrentCapacity() { 
     return m_CurrentCapacity; 
   }

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -153,10 +153,10 @@ class J1772EVSEController {
   unsigned long m_StuckRelayStartTimeMS;
   uint8_t m_StuckRelayTripCnt; // contains tripcnt-1
 #endif // ADVPWR
-#ifdef RELAY_AUTO_PWM_PIN_TESTING
-  unsigned long m_relayCloseMs; // #ms for DC pulse to close relay
+#ifdef RELAY_PWM
+  uint8_t m_relayCloseMs; // #ms for DC pulse to close relay
   uint8_t m_relayHoldPwm; // PWM duty cycle to hold relay closed
-#endif // RELAY_AUTO_PWM_PIN_TESTING
+#endif // RELAY_PWM
   uint16_t m_wFlags; // ECF_xxx
   uint16_t m_wVFlags; // ECVF_xxx
   THRESH_DATA m_ThreshData;
@@ -184,6 +184,11 @@ class J1772EVSEController {
 #ifdef OVERCURRENT_THRESHOLD
   unsigned long m_OverCurrentStartMs;
 #endif // OVERCURRENT_THRESHOLD
+#ifdef OEV6
+  uint8_t m_isV6;
+#endif
+
+
   void setFlags(uint16_t flags) { 
     m_wFlags |= flags; 
   }
@@ -205,6 +210,10 @@ class J1772EVSEController {
   uint8_t vFlagIsSet(uint16_t flag) {
     return (m_wVFlags & flag) ? 1 : 0;
   }
+
+#ifdef OEV6
+  uint8_t isV6() { return m_isV6; }
+#endif
 
 #ifdef ADVPWR
 // power states for doPost() (active low)
@@ -286,12 +295,12 @@ public:
     return ((m_EvseState >= EVSE_FAULT_STATE_BEGIN) && (m_EvseState <= EVSE_FAULT_STATE_END));
   }
 
-#ifdef RELAY_AUTO_PWM_PIN_TESTING
-  void setPwmPinParms(uint32_t delayms,uint8_t pwm) {
+#ifdef RELAY_PWM
+  void setPwmPinParms(uint8_t delayms,uint8_t pwm) {
     m_relayCloseMs = delayms;
     m_relayHoldPwm = pwm;
   }
-#endif
+#endif // RELAY_PWM
 
   void SetHardFault() { setVFlags(ECVF_HARD_FAULT); }
   void ClrHardFault() { clrVFlags(ECVF_HARD_FAULT); }

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -256,8 +256,8 @@ class J1772EVSEController {
 #ifdef VOLTMETER
   uint16_t m_VoltScaleFactor;
   uint32_t m_VoltOffset;
-  uint32_t m_Voltage; // mV
 #endif // VOLTMETER
+  uint32_t m_Voltage; // mV
 
 #ifdef HEARTBEAT_SUPERVISION
   uint16_t      m_HsInterval;   // Number of seconds HS will wait for a heartbeat before reducing ampacity to m_IFallback.  If 0 disable.
@@ -429,9 +429,6 @@ int GetHearbeatTrigger();
   uint32_t GetVoltOffset() { return m_VoltOffset; }
   void SetVoltmeter(uint16_t scale,uint32_t offset);
   uint32_t ReadVoltmeter();
-  int32_t GetVoltage() { return m_Voltage; }
-#else
-  uint32_t GetVoltage() { return (uint32_t)-1; }
 #endif // VOLTMETER
 #ifdef AMMETER
   int32_t GetChargingCurrent() {
@@ -543,6 +540,11 @@ int GetHearbeatTrigger();
   }
   uint8_t ButtonIsEnabled() { return flagIsSet(ECF_BUTTON_DISABLED) ? 0 : 1; }
 #endif // BTN_MENU
+
+#if defined(KWH_RECORDING) && !defined(VOLTMETER)
+  void SetMV(uint32_t mv) { m_Voltage = mv; }
+#endif
+  int32_t GetVoltage() { return m_Voltage; }
 };
 
 #ifdef FT_ENDURANCE

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -104,10 +104,10 @@ typedef uint8_t (*EvseStateTransitionReqFunc)(uint8_t prevPilotState,uint8_t cur
 
 #define HS_INTERVAL_DEFAULT     0x0000  //By default, on an unformatted EEPROM, Heartbeat Supervision is not activated
 #define HS_IFALLBACK_DEFAULT    0x00    //By default, on an unformatted EEPROM, HS fallback current is 0 Amperes 
-#define HS_ACK_COOKIE           0XA5    //ACK will not work unless it contin this cookie
+#define HS_ACK_COOKIE           0XA5    //ACK will not work unless it contains this cookie
 #define HS_MISSEDPULSE_NOACK    0x02    //HEARTBEAT_SUPERVISION missed a pulse and this has not been acknowleged
 #define HS_MISSEDPULSE          0x01    //HEARTBEAT_SUPERVISION missed a pulse and this is the semi-permanent record flag
-
+//#define DEBUG_HS //Uncomment this for debugging statemnts sent to serial port
 
 class J1772EVSEController {
   J1772Pilot m_Pilot;
@@ -250,10 +250,10 @@ class J1772EVSEController {
 #endif // VOLTMETER
 
 #ifdef HEARTBEAT_SUPERVISION
-  uint16_t     m_HsInterval;          // Number of seconds HS will wait for a heartbeat before reducing ampacity to m_IFallback.  If 0 disable.
-  uint8_t      m_IFallback;           // HEARTBEAT_SUPERVISION fallback current in Amperes.  
-  uint8_t     m_HsTriggered;        // Will be 0 if HEARTBEAT_SUPERVISION has never had a missed pulse
-  unsigned long m_HsLastPulse;    // The last time we saw a HS pulse or the last time m_HsInterval elpased without seeing one.  Set to 0 if HEARTBEAT_SUPERVISION triggered                                   
+  uint16_t      m_HsInterval;   // Number of seconds HS will wait for a heartbeat before reducing ampacity to m_IFallback.  If 0 disable.
+  uint8_t       m_IFallback;    // HEARTBEAT_SUPERVISION fallback current in Amperes.  
+  uint8_t       m_HsTriggered;  // Will be 0 if HEARTBEAT_SUPERVISION has never had a missed pulse
+  unsigned long m_HsLastPulse;  // The last time we saw a HS pulse or the last time m_HsInterval elpased without seeing one.  Set to 0 if HEARTBEAT_SUPERVISION triggered                                   
 #endif //HEARTBEAT_SUPERVISION
 
 public:

--- a/firmware/open_evse/avrstuff.h
+++ b/firmware/open_evse/avrstuff.h
@@ -54,7 +54,7 @@ public:
 #define _DPIN_SET(reg,idx) {PORT ## reg |= (1<<idx);}
 #define _DPIN_CLR(reg,idx) {PORT ## reg &= ~(1<<idx);}
 #define _DPIN_WRITE(reg,idx,val) {if (val) DPIN_SET(reg,idx); else DPIN_CLR(reg,idx); }
-#define _DPIN_MODE_INPUT(reg,idx) {DDR ## reg &= ~(1<<idx)}
+#define _DPIN_MODE_INPUT(reg,idx) {DDR ## reg &= ~(1<<idx);}
 #define _DPIN_MODE_PULLUP(reg,idx) { DPIN_SET(reg,idx);DPIN_MODE_INPUT(reg,idx);}
 #define _DPIN_MODE_OUTPUT(reg,idx) {DDR ## reg |= (1<<idx);}
 

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -697,12 +697,6 @@ extern AutoCurrentCapacityController g_ACCController;
 #define DEFAULT_AMMETER_CURRENT_OFFSET 0   // OpenEVSE v2.5 and v3 with a 22 Ohm burden resistor.  Could use a more thorough calibration exercise to nails this down.
 #endif
 
-#ifdef KWH_RECORDING
-#define VOLTS_FOR_L1 120       // conventional for North America
-#define VOLTS_FOR_L2 240       // conventional for North America and Commonwealth countries
-//  #define VOLTS_FOR_L2 230   // conventional for most of the world
-#endif // KWH_RECORDING
-
 // The maximum number of milliseconds to sample an ammeter pin in order to find three zero-crossings.
 // one and a half cycles at 50 Hz is 30 ms.
 #define CURRENT_SAMPLE_INTERVAL 35

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -53,6 +53,12 @@
 //-- begin features
 
 //#define OCPP
+// V6 hardware
+#define OEV6
+#define V6_CHARGING_PIN  5
+#define V6_CHARGING_PIN2 6
+#define RELAY_PWM
+#define RELAY_HOLD_DELAY_TUNING // enable Z0
 
 // auto detect L1/L2
 #define AUTOSVCLEVEL
@@ -317,8 +323,8 @@ extern AutoCurrentCapacityController g_ACCController;
 // and m_relayHoldPwm below
 //#define RELAY_AUTO_PWM_PIN_TESTING
 #ifndef RELAY_AUTO_PWM_PIN_TESTING
-#define m_relayCloseMs 250UL
-#define m_relayHoldPwm 50 // duty cycle 0-255
+//#define m_relayCloseMs 250UL
+//#define m_relayHoldPwm 50 // duty cycle 0-255
 #endif //RELAY_AUTO_PWM_PIN_TESTING
 
 //-- end features
@@ -552,15 +558,8 @@ extern AutoCurrentCapacityController g_ACCController;
 // Fallback Current in quarter Amperes:
 #define EOFS_HEARTBEAT_SUPERVISION_CURRENT 36 // 1 byte 
 
-//- start TESTING ONLY
-#ifdef RELAY_AUTO_PWM_PIN_TESTING
-#define EOFS_RELAY_HOLD_PWM 512
-#define EOFS_RELAY_CLOSE_MS 513
-#endif //  RELAY_AUTO_PWM_PIN_TESTING
-#ifdef RELAY_HOLD_DELAY_TUNING
-#define EOFS_RELAY_HOLD_DELAY 512
-#endif // RELAY_HOLD_DELAY_TUNING
-//- end TESTING ONLY
+#define EOFS_RELAY_CLOSE_MS 37 // 1 byte
+#define EOFS_RELAY_HOLD_PWM 38 // 1 byte
 
 
 
@@ -578,6 +577,11 @@ extern AutoCurrentCapacityController g_ACCController;
 // for SAMPLE_ACPINS - max number of ms to sample
 #define AC_SAMPLE_MS 20 // 1 cycle @ 60Hz = 16.6667ms @ 50Hz = 20ms
 
+
+// V6 has PD7 tied to ground
+#define V6_ID_REG D
+#define V6_ID_IDX 7
+
 #ifdef GFI
 #define GFI_INTERRUPT 0 // interrupt number 0 = PD2, 1 = PD3
 // interrupt number 0 = PD2, 1 = PD3
@@ -588,6 +592,11 @@ extern AutoCurrentCapacityController g_ACCController;
 // pin is supposed to be wrapped around the GFI CT 5+ times
 #define GFITEST_REG &PIND
 #define GFITEST_IDX 6
+// V6 GFI test pin PB0
+#define V6_GFITEST_REG &PINB
+#define V6_GFITEST_IDX 0
+
+
 
 #define GFI_TEST_CYCLES 60
 // GFI pulse should be 50% duty cycle

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -42,7 +42,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D6.2.1"
+#define VERSION "D7.0.0"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer
@@ -53,12 +53,12 @@
 //-- begin features
 
 //#define OCPP
-// V6 hardware
-#define OEV6
-#define V6_CHARGING_PIN  5
-#define V6_CHARGING_PIN2 6
+// support V6 hardware
+//#define OEV6
+#ifdef OEV6
 #define RELAY_PWM
 #define RELAY_HOLD_DELAY_TUNING // enable Z0
+#endif // OEV6
 
 // auto detect L1/L2
 #define AUTOSVCLEVEL
@@ -316,16 +316,12 @@ extern AutoCurrentCapacityController g_ACCController;
 // switch to m_relayHoldPwm
 // ONLY WORKS PWM-CAPABLE PINS!!!
 // use Arduino pin number PD5 = 5, PD6 = 6
-//#define RELAY_AUTO_PWM_PIN 5
+//#define RELAY_PWM
+#define DEFAULT_RELAY_CLOSE_MS 25
+#define DEFAULT_RELAY_HOLD_PWM 75 // (0-255, where 0=0%, 255=100%
 // enables RAPI $Z0 for tuning PWM (see rapi_proc.h for $Z0 syntax)
 // PWM parameters written to/loaded from EEPROM
-// when done tuning, put hardcoded parameters into m_relayCloseMs
-// and m_relayHoldPwm below
-//#define RELAY_AUTO_PWM_PIN_TESTING
-#ifndef RELAY_AUTO_PWM_PIN_TESTING
-//#define m_relayCloseMs 250UL
-//#define m_relayHoldPwm 50 // duty cycle 0-255
-#endif //RELAY_AUTO_PWM_PIN_TESTING
+//#define RELAY_HOLD_DELAY_TUNING // enable Z0
 
 //-- end features
 
@@ -468,7 +464,9 @@ extern AutoCurrentCapacityController g_ACCController;
 #define ACLINE2_REG &PIND
 #define ACLINE2_IDX 4
 
-#ifndef RELAY_AUTO_PWM_PIN
+#define V6_CHARGING_PIN  5
+#define V6_CHARGING_PIN2 6
+
 // digital Relay trigger pin
 #define CHARGING_REG &PINB
 #define CHARGING_IDX 0
@@ -478,7 +476,6 @@ extern AutoCurrentCapacityController g_ACCController;
 //digital Charging pin for AC relay
 #define CHARGINGAC_REG &PINB
 #define CHARGINGAC_IDX 1
-#endif // !RELAY_AUTO_PWM_PIN
 
 // obsolete LED pin
 //#define RED_LED_REG &PIND

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -83,7 +83,7 @@
 #define RAPI_SERIAL
 
 // RAPI $WF support
-#define RAPI_WF
+//#define RAPI_WF
 
 // RAPI over I2C
 //#define RAPI_I2C

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -561,6 +561,8 @@ extern AutoCurrentCapacityController g_ACCController;
 #define EOFS_RELAY_CLOSE_MS 37 // 1 byte
 #define EOFS_RELAY_HOLD_PWM 38 // 1 byte
 
+#define EOFS_MAX_HW_CURRENT_CAPACITY 511 // 1 byte
+
 
 
 // must stay within thresh for this time in ms before switching states

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -1589,7 +1589,7 @@ void MaxCurrentMenu::Init()
     m_MaxCurrent = MAX_CURRENT_CAPACITY_L1;
   }
   else {
-    m_MaxCurrent = MAX_CURRENT_CAPACITY_L2;
+    m_MaxCurrent = g_EvseController.GetMaxHwCurrentCapacity();
   }
   
   sprintf(g_sTmp,g_sMaxCurrentFmt,(cursvclvl == 1) ? "L1" : "L2");

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -496,6 +496,15 @@ int EvseRapiProcessor::processCmd()
       break;
 #endif // DELAYTIMER      
 
+#if defined(KWH_RECORDING) && !defined(VOLTMETER)
+    case 'V': // set voltage
+      if (tokenCnt == 2) {
+        g_EvseController.SetMV(dtou32(tokens[1]));
+	rc = 0;
+      }
+      break;
+#endif //defined(KWH_RECORDING) && !defined(VOLTMETER)
+
 #ifdef HEARTBEAT_SUPERVISION
     case 'Y': // HEARTBEAT SUPERVISION
       if (tokenCnt == 1)  { //This is a heartbeat

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -397,30 +397,35 @@ int EvseRapiProcessor::processCmd()
 #endif // AMMETER
     case 'C': // current capacity
       if ((tokenCnt == 2) || (tokenCnt == 3)) {
-	if (tokenCnt == 3) {
-	  // just make volatile no matter what character specified
-	  u1.u8 = 1; // nosave = 1
-	}
-	else {
-	  u1.u8 = 0; // nosave = 0
-	}
-#ifdef TEMPERATURE_MONITORING
 	u2.u8 = dtou32(tokens[1]);
-	if (g_TempMonitor.OverTemperature() &&
-	    (u2.u8 > g_EvseController.GetCurrentCapacity())) {
-	  // don't allow raising current capacity during
-	  // overtemperature event
-	  rc = 1;
+	if ((tokenCnt == 3) && (*tokens[2] == 'M')) {
+	  rc = g_EvseController.SetMaxHwCurrentCapacity(u2.u8);
+	  sprintf(buffer,"%d",(int)g_EvseController.GetMaxHwCurrentCapacity());
 	}
 	else {
-	  rc = g_EvseController.SetCurrentCapacity(u2.u8,1,u1.u8);
-	}
+	  if (tokenCnt == 3) {
+	    // just make volatile no matter what character specified
+	    u1.u8 = 1; // nosave = 1
+	  }
+	  else {
+	    u1.u8 = 0; // nosave = 0
+	  }
+#ifdef TEMPERATURE_MONITORING
+	  if (g_TempMonitor.OverTemperature() &&
+	      (u2.u8 > g_EvseController.GetCurrentCapacity())) {
+	    // don't allow raising current capacity during
+	    // overtemperature event
+	    rc = 1;
+	  }
+	  else {
+	    rc = g_EvseController.SetCurrentCapacity(u2.u8,1,u1.u8);
+	  }
 #else // !TEMPERATURE_MONITORING
-	rc = g_EvseController.SetCurrentCapacity(u2.u8,1,u1.u8);
+	  rc = g_EvseController.SetCurrentCapacity(u2.u8,1,u1.u8);
 #endif // TEMPERATURE_MONITORING
-
-
-	sprintf(buffer,"%d",(int)g_EvseController.GetCurrentCapacity());
+  
+	  sprintf(buffer,"%d",(int)g_EvseController.GetCurrentCapacity());
+	}
 	bufCnt = 1; // flag response text output
       }
       break;
@@ -564,7 +569,7 @@ int EvseRapiProcessor::processCmd()
     case 'C': // get current capacity range
       u1.i = MIN_CURRENT_CAPACITY_J1772;
       if (g_EvseController.GetCurSvcLevel() == 2) {
-	u2.i = MAX_CURRENT_CAPACITY_L2;
+	u2.i = g_EvseController.GetMaxHwCurrentCapacity();
       }
       else {
 	u2.i = MAX_CURRENT_CAPACITY_L1;
@@ -729,20 +734,22 @@ int EvseRapiProcessor::processCmd()
 #if defined(RELAY_HOLD_DELAY_TUNING)
   case 'Z': // reserved op
     switch(*s) {
-    case '1': // set relayCloseMs
-      if (tokenCnt == 2) {
-	u1.u32 = dtou32(tokens[1]);
-	g_EvseController.setRelayHoldDelay(u1.u32);
-	sprintf(g_sTmp,"\nZ1 %ld",u1.u32);
+    case '0': // set relayCloseMs
+      if (tokenCnt == 3) {
+	u1.u8 = dtou32(tokens[1]);
+	u2.u8 = dtou32(tokens[2]);
+	g_EvseController.setPwmPinParms(u1.u8,u2.u8);
+	sprintf(g_sTmp,"\nZ0 %u %u",(unsigned)u1.u8,(unsigned)u2.u8);
 	Serial.println(g_sTmp);
-	eeprom_write_dword((uint32_t*)EOFS_RELAY_HOLD_DELAY,u1.u32);
+	eeprom_write_byte((uint8_t*)EOFS_RELAY_CLOSE_MS,u1.u8);
+	eeprom_write_byte((uint8_t*)EOFS_RELAY_HOLD_PWM,u2.u8);
       }
       rc = 0;
       break;
 
     }
     break;
-#endif // RELAY_AUTO_PWM_PIN_TESTING
+#endif // RELAY_HOLD_DELAY_TUNING
 
   default:
     ; // do nothing

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -193,6 +193,11 @@ SL 1|2|A  - set service level L1/L2/Auto
 SM voltscalefactor voltoffset - set voltMeter settings
 ST starthr startmin endhr endmin - set timer
  $ST 0 0 0 0^23 - cancel timer
+SV mv - Set Voltage for power calculations to mv millivolts
+ $SV 223576 - set voltage to 223.576
+ NOTES:
+  - only available if VOLTMETER not defined and KWH_RECORDING defined
+  - volatile - value is lost, and replaced with VOLTS_FOR_Lx at boot
 SY heartbeatinterval hearbeatcurrentlimit
  Response includes heartbeatinterval hearbeatcurrentlimit hearbeattrigger
  hearbeattrigger: 0 - There has never been a missed pulse, 
@@ -251,7 +256,6 @@ GF - get fault counters
 GG - get charging current and voltage
  response: $OK milliamps millivolts
  AMMETER must be defined in order to get amps, otherwise returns -1 amps
- VOLTMETER must be defined in order to get voltage, otherwise returns -1 volts
  $GG^24
 
 GH - get cHarge limit
@@ -321,7 +325,7 @@ Z0 closems holdpwm
 
 #ifdef RAPI
 
-#define RAPIVER "5.1.2"
+#define RAPIVER "5.1.3"
 
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_CLIENT 1

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -321,7 +321,7 @@ Z0 closems holdpwm
 
 #ifdef RAPI
 
-#define RAPIVER "5.1.1"
+#define RAPIVER "5.1.2"
 
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_CLIENT 1

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -161,16 +161,20 @@ S4 0|1 - set auth lock (needs AUTH_LOCK defined and AUTH_LOCK_REG undefined)
    when auth lock is on, will not transition to State C and a lock icon is
    displayed in States A & B.
 SA currentscalefactor currentoffset - set ammeter settings
-SC amps [V]- set current capacity
+SC amps [V|M]- set current capacity
  response:
    if amps < minimum current capacity, will set to minimum and return $NK ampsset
    if amps > maximum current capacity, will set to maximum and return $NK ampsset
    if in over temperature status, raising current capacity will fail and return $NK ampsset
    otherwise return $OK ampsset
    ampsset: the resultant current capacity
-   default action is to save new current capacity to EEPROM.
+   default action is to save new current capacity to EEPROM for the currently active service level.
    if V is specified, then new current capacity is volatile, and will be
      reset to previous value at next reboot
+   if M is specified, sets maximum L2 current capacity for the unit and writes
+     to EEPROM. subsequent calls the $SC cannot exceed value set bye $SC M
+     the value cannot be changed/erased via RAPI commands. Subsequent calls
+     to $SC M will return $NK
 SH kWh - set cHarge limit to kWh
  NOTES:
   - allowed only when EV connected in State B or C
@@ -317,7 +321,7 @@ Z0 closems holdpwm
 
 #ifdef RAPI
 
-#define RAPIVER "5.1.0"
+#define RAPIVER "5.1.1"
 
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_CLIENT 1

--- a/firmware/open_evse/rapi_proc.h
+++ b/firmware/open_evse/rapi_proc.h
@@ -193,10 +193,10 @@ SY heartbeatinterval hearbeatcurrentlimit
  Response includes heartbeatinterval hearbeatcurrentlimit hearbeattrigger
  hearbeattrigger: 0 - There has never been a missed pulse, 
  2 - there is a missed pulse, and HS is still in current limit
- 1 - There was a missed pulse once, but it has since been acknkoledged. Ampacity has been successfully restored to max permitted 
+ 1 - There was a missed pulse once, but it has since been acknowledged. Ampacity has been successfully restored to max permitted 
  $SY 100 6  //If no pulse for 100 seconds, set EVE ampacity limit to 6A until missed pulse is acknowledged
  $SY        //This is a heartbeat supervision pulse.  Need one every heartbeatinterval seconds.
- $SY 165    //This is an acknowledgemnt of a missed pulse.  Magic Cookie = 165 (=0XA5)
+ $SY 165    //This is an acknowledgement of a missed pulse.  Magic Cookie = 165 (=0XA5)
  When you send a pulse, an NK response indicates that a previous pulse was missed and has not yet been acked
 
 G0 - get EV connect state

--- a/firmware/open_evse/serialcli.cpp
+++ b/firmware/open_evse/serialcli.cpp
@@ -82,7 +82,7 @@ void CLI::getInput()
         print_P(PSTR("Min Current Capacity: "));
         Serial.println(MIN_CURRENT_CAPACITY_J1772);
         print_P(PSTR("Max Current Capacity: "));
-        Serial.println((g_EvseController.GetCurSvcLevel() == 2) ? MAX_CURRENT_CAPACITY_L2 : MAX_CURRENT_CAPACITY_L1);
+        Serial.println((g_EvseController.GetCurSvcLevel() == 2) ? g_EvseController.GetMaxHwCurrentCapacity() : MAX_CURRENT_CAPACITY_L1);
 	print_P(PSTR("Vent Required: "));
 	println_P(g_EvseController.VentReqEnabled() ? s_psEnabled : s_psDisabled);
          print_P(PSTR("Diode Check: "));
@@ -224,7 +224,7 @@ void CLI::getInput()
      print_P(PSTR("Enter amps ("));
           Serial.print((g_EvseController.GetCurSvcLevel() == 2) ? MIN_CURRENT_CAPACITY_L2 : MIN_CURRENT_CAPACITY_L1);
      print_P(PSTR("-"));
-     Serial.print((g_EvseController.GetCurSvcLevel()  == 1) ? MAX_CURRENT_CAPACITY_L1 : MAX_CURRENT_CAPACITY_L2);
+     Serial.print((g_EvseController.GetCurSvcLevel()  == 1) ? MAX_CURRENT_CAPACITY_L1 : g_EvseController.GetMaxHwCurrentCapacity());
      print_P(PSTR("): "));
      amp = getInt();
      Serial.println((int)amp);

--- a/utils/calcalc.cpp
+++ b/utils/calcalc.cpp
@@ -1,0 +1,22 @@
+/*
+ * Author: Sam C. Lin 20200515
+ * Copyright (c) Sam C. Lin 2020 ALL RIGHTS RESERVED
+ */
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+int main(int argc,char *argv[])
+{
+  printf("RAPI Calibration Calculator V1.0 (%s %s)\n\n",__DATE__,__TIME__);
+  printf("Enter raw1 measured1 raw2 measured2\n");
+  char cmdbuf[80];
+  gets_s(cmdbuf,sizeof(cmdbuf));
+  double raw1,raw2,measured1,measured2,scale,offset;
+  sscanf(cmdbuf,"%lf %lf %lf %lf",&raw1,&measured1,&raw2,&measured2);
+  printf("raw1: %lf measured1: %lf\n",raw1,measured1);
+  printf("raw2: %lf measured2: %lf\n",raw2,measured2);
+  scale = (measured2-measured1)/(raw2-raw1);
+  offset = measured2 - (raw2*scale);
+  printf("\nscale: %d\noffset: %d\n",(int)(scale+0.5),(int)(offset+0.5));
+}


### PR DESCRIPTION
**RAPI  V5.1.3**

20200507 SCL V7.0.1
- added $SV command to set VRMS voltage 

20200507 SCL V7.0.0
- added OpenEVSE V6 support
  - detection by looking for PD7 LOW
  - RELAY_PWM - close relay w/ DC and the switch to PWM for hold
  - if not V6 hardware detected same behaviour as before on charging pin
- added $SC M to set max hardware current capacity. Can be written only once

D6.3.0 2020420 SCL
- merge $SC M code from oev6 branch
- merge PR#120 https://github.com/lincomatic/open_evse/pull/120 Added debug statements to Heartbeat Supervision f