### PR TITLE
V7.0.2

### DIFF
--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,12 @@
 Change Log
 
+20200816 SCL V7.0.2
+- get rid of LoadThresholds()/g_DefaultThreshData to save space
+  -> fixes a bug that crept in to DoPost() when I changed hardcoded value to 
+	    if (reading >= m_ThreshData.m_ThreshAB) {
+	-> was testing against m_ThreshData before initializing it, so the code was executing, even when an EV connected
+- fix compiler warning in SetupMenu::Select()
+	
 20200507 SCL V7.0.1
 - added $SV
 	

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -26,8 +26,8 @@ long g_CycleHalfStart;
 uint8_t g_CycleState;
 #endif 
 
-//                                 A/B B/C C/D D DS
-THRESH_DATA g_DefaultThreshData = {875,780,690,0,260};
+//                                               A/B B/C C/D D DS
+THRESH_DATA J1772EVSEController::m_ThreshData = {875,780,690,0,260};
 
 J1772EVSEController g_EvseController;
 
@@ -567,11 +567,6 @@ void J1772EVSEController::Sleep()
   }
 }
 
-void J1772EVSEController::LoadThresholds()
-{
-  memcpy(&m_ThreshData,&g_DefaultThreshData,sizeof(m_ThreshData));
-}
-
 void J1772EVSEController::SetSvcLevel(uint8_t svclvl,uint8_t updatelcd)
 {
 #ifdef SERDBG
@@ -593,8 +588,6 @@ void J1772EVSEController::SetSvcLevel(uint8_t svclvl,uint8_t updatelcd)
 
   uint8_t ampacity = GetMaxCurrentCapacity();
 
-
-  LoadThresholds();
 
   SetCurrentCapacity(ampacity,0,1);
 

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -159,7 +159,7 @@ class J1772EVSEController {
 #endif // RELAY_PWM
   uint16_t m_wFlags; // ECF_xxx
   uint16_t m_wVFlags; // ECVF_xxx
-  THRESH_DATA m_ThreshData;
+  static THRESH_DATA m_ThreshData;
   uint8_t m_EvseState;
   uint8_t m_PrevEvseState;
   uint8_t m_TmpEvseState;
@@ -273,7 +273,6 @@ public:
   void Enable();
   void Disable(); // panic stop - open relays abruptly
   void Sleep(); // graceful stop - e.g. waiting for timer to fire- give the EV time to stop charging first
-  void LoadThresholds();
 
   uint16_t GetFlags() { return m_wFlags; }
   uint16_t GetVFlags() { return m_wVFlags; }

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -42,7 +42,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D7.0.0"
+#define VERSION "D7.0.2"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer

--- a/firmware/open_evse/open_evse.ino
+++ b/firmware/open_evse/open_evse.ino
@@ -1210,6 +1210,7 @@ Menu *SetupMenu::Select()
   else {
     m_CurIdx = 0;
     g_EvseController.Reboot();
+    return &g_SetupMenu;
   }
 }
 


### PR DESCRIPTION
V7.0.2
- get rid of LoadThresholds()/g_DefaultThreshData to save space
  -> fixes a bug that crept in to DoPost() when I changed hardcoded value to 
	    if (reading >= m_ThreshData.m_ThreshAB) {
	-> was testing against m_ThreshData before initializing it, so the code was executing, even when an EV connected
- fix compiler warning in SetupMenu::Select()