### PR TITLE
V7.1.3

### DIFF
--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,5 +1,8 @@
 Change Log
 
+202100208 SCL V7.1.3
+- flip polarity of V6 detection .. HIGH = V6
+	
 202100208 SCL V7.1.2
 - fix spontaneous reboot caused by PR#134 RAPI_BTN code
   -> when button disabled, didn't pat the watchdog before m_Btn.read()

--- a/firmware/open_evse/CHANGELOG
+++ b/firmware/open_evse/CHANGELOG
@@ -1,6 +1,6 @@
 Change Log
 
-202100208 SCL V7.1.3
+202100311 SCL V7.1.3
 - flip polarity of V6 detection .. HIGH = V6
 	
 202100208 SCL V7.1.2

--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -916,7 +916,7 @@ void J1772EVSEController::Init()
 {
 #ifdef OEV6
   DPIN_MODE_INPUT(V6_ID_REG,V6_ID_IDX);
-  if (!DPIN_READ(V6_ID_REG,V6_ID_IDX)) m_isV6 = 1;
+  if (DPIN_READ(V6_ID_REG,V6_ID_IDX)) m_isV6 = 1;
   else m_isV6 = 0;
   //  Serial.print("isV6: ");Serial.println(isV6());
 #endif

--- a/firmware/open_evse/open_evse.h
+++ b/firmware/open_evse/open_evse.h
@@ -41,7 +41,7 @@
 #define clrBits(flags,bits) (flags &= ~(bits))
 
 #ifndef VERSION
-#define VERSION "D7.1.2"
+#define VERSION "D7.1.3"
 #endif // !VERSION
 
 #include "Language_default.h"   //Default language should always be included as bottom layer


### PR DESCRIPTION
- Autodetection of openevse controller hardware V5.5, PD7 is tied high on 5.5 Controllers and LOW (by default) on pre v5 `#define OEV6` 